### PR TITLE
Improve test module detection on Mill 0.11.7+

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.13"
+version = "3.7.15"
 
 align.preset = none
 align.openParenCallSite = false
@@ -16,3 +16,6 @@ docstrings.wrap = no
 maxColumn = 120
 
 newlines.source = keep
+
+runner.dialect = scala213
+

--- a/build.sc
+++ b/build.sc
@@ -32,17 +32,17 @@ trait Deps {
 object Deps_0_11 extends Deps {
   override def millPlatform = "0.11" // only valid for exact milestone versions
   override def millVersion = "0.11.0" // scala-steward:off
-  override def testWithMill = Seq(millVersion)
+  override def testWithMill = Seq("0.11.6", millVersion)
 }
 object Deps_0_10 extends Deps {
   override def millPlatform = "0.10"
   override def millVersion = "0.10.0" // scala-steward:off
-  override def testWithMill = Seq(millVersion, "0.10.11")
+  override def testWithMill = Seq("0.10.13", millVersion)
 }
 object Deps_0_9 extends Deps {
   override def millPlatform = "0.9"
   override def millVersion = "0.9.7" // scala-steward:off
-  override def testWithMill = Seq(millVersion, "0.9.12")
+  override def testWithMill = Seq("0.9.12", millVersion)
 }
 
 val crossDeps = Seq(Deps_0_11, Deps_0_10, Deps_0_9)

--- a/build.sc
+++ b/build.sc
@@ -32,7 +32,7 @@ trait Deps {
 object Deps_0_11 extends Deps {
   override def millPlatform = "0.11" // only valid for exact milestone versions
   override def millVersion = "0.11.0" // scala-steward:off
-  override def testWithMill = Seq("0.11.6", millVersion)
+  override def testWithMill = Seq("0.11.7", "0.11.6", millVersion)
 }
 object Deps_0_10 extends Deps {
   override def millPlatform = "0.10"

--- a/core/src-0.10-/de/tobiasroeser/mill/jacoco/JacocoReportModulePlatform.scala
+++ b/core/src-0.10-/de/tobiasroeser/mill/jacoco/JacocoReportModulePlatform.scala
@@ -27,15 +27,20 @@ trait JacocoReportModulePlatform extends CoursierModule {
     jars.iterator.next()
   }
 
-  protected[jacoco] def resolveTasks[T](tasks: String, evaluator: Evaluator): Seq[Task[T]] = RunScript.resolveTasks(
-    mill.main.ResolveTasks,
-    evaluator,
-    Seq(tasks),
-    multiSelect = true
-  ) match {
-    case Left(err) => throw new Exception(err)
-    case Right(tasks) => tasks.asInstanceOf[Seq[Task[T]]]
-  }
+  protected[jacoco] def resolveTasks[T](tasks: String, evaluator: Evaluator): Seq[Task[T]] =
+    if (tasks.trim().isEmpty()) Seq()
+    else RunScript.resolveTasks(
+      mill.main.ResolveTasks,
+      evaluator,
+      Seq(tasks),
+      multiSelect = true
+    ) match {
+      case Left(err) => throw new Exception(err)
+      case Right(tasks) => tasks.asInstanceOf[Seq[Task[T]]]
+    }
 
+  protected[jacoco] val (sourcesSelector, compileSelector, excludeSourcesSelector, excludeCompiledSelector) = {
+    ("__.allSources", "__.compile", "__.test.allSources", "__.test.compile")
+  }
 
 }

--- a/core/src-0.11/de/tobiasroeser/mill/jacoco/JacocoReportModulePlatform.scala
+++ b/core/src-0.11/de/tobiasroeser/mill/jacoco/JacocoReportModulePlatform.scala
@@ -39,7 +39,7 @@ trait JacocoReportModulePlatform extends CoursierModule {
   }
 
   protected[jacoco] val (sourcesSelector, compileSelector, excludeSourcesSelector, excludeCompiledSelector) = {
-    // since version 0.11.7 Mill support type selectors in target queries
+    // since version 0.11.7 Mill supports type selectors in target queries
     // https://github.com/com-lihaoyi/mill/pull/2997
     if (
       Version.parse(mill.api.BuildInfo.millVersion).isAtLeast(Version.parse("0.11.7"))(

--- a/core/src-0.11/de/tobiasroeser/mill/jacoco/JacocoReportModulePlatform.scala
+++ b/core/src-0.11/de/tobiasroeser/mill/jacoco/JacocoReportModulePlatform.scala
@@ -2,16 +2,16 @@ package de.tobiasroeser.mill.jacoco
 
 import mill.{Agg, T}
 import mill.api.PathRef
-import mill.define.{Input, Task}
+import mill.define.Task
 import mill.eval.Evaluator
-import mill.main.RunScript
 import mill.resolve.{Resolve, SelectMode}
 import mill.scalalib.{CoursierModule, DepSyntax}
+import mill.util.Version
 
 trait JacocoReportModulePlatform extends CoursierModule {
 
   /** The Jacoco Version. */
-  def jacocoVersion: Input[String]
+  def jacocoVersion: T[String]
 
   /** The Jacoco Classpath contains the tools used to generate reports from collected coverage data. */
   def jacocoClasspath: T[Agg[PathRef]] = T {
@@ -31,11 +31,23 @@ trait JacocoReportModulePlatform extends CoursierModule {
   }
 
   protected[jacoco] def resolveTasks[T](tasks: String, evaluator: Evaluator): Seq[Task[T]] = {
-    Resolve.Tasks.resolve(evaluator.rootModule, Seq(tasks), SelectMode.Multi) match {
+    if (tasks.trim().isEmpty()) Seq()
+    else Resolve.Tasks.resolve(evaluator.rootModule, Seq(tasks), SelectMode.Multi) match {
       case Left(err) => throw new Exception(err)
       case Right(tasks) => tasks.asInstanceOf[Seq[Task[T]]]
     }
   }
 
+  protected[jacoco] val (sourcesSelector, compileSelector, excludeSourcesSelector, excludeCompiledSelector) = {
+    // since version 0.11.7 Mill support type selectors in target queries
+    // https://github.com/com-lihaoyi/mill/pull/2997
+    if (
+      Version.parse(mill.api.BuildInfo.millVersion).isAtLeast(Version.parse("0.11.7"))(
+        mill.util.Version.IgnoreQualifierOrdering
+      )
+    ) ("__:JavaModule:^TestModule.allSources", "__:JavaModule:^TestModule.compile", "", "")
+      else
+      ("__.allSources", "__.compile", "__.test.allSources", "__.test.compile")
+  }
 
 }

--- a/core/src/de/tobiasroeser/mill/jacoco/JacocoReportModule.scala
+++ b/core/src/de/tobiasroeser/mill/jacoco/JacocoReportModule.scala
@@ -35,10 +35,10 @@ trait JacocoReportModule extends JacocoReportModulePlatform { jacocoReportModule
   def jacocoReportFull(evaluator: mill.eval.Evaluator): Command[PathRef] = T.command {
     jacocoReportTask(
       evaluator = evaluator,
-      sources = "__.allSources",
-      compiled = "__.compile",
-      excludeSources = "__.test.allSources",
-      excludeCompiled = "__.test.compile"
+      sources = sourcesSelector,
+      compiled = compileSelector,
+      excludeSources = excludeSourcesSelector,
+      excludeCompiled = excludeCompiledSelector
     )()
   }
 

--- a/itest/src-0.11+/custom-test/build.sc
+++ b/itest/src-0.11+/custom-test/build.sc
@@ -8,7 +8,10 @@ import mill.scalalib._
 import mill.define.Command
 
 object main extends JavaModule {
-  object test extends JavaModuleTests with JacocoTestModule with TestModule.Junit4 {
+  // no tests in here
+  object test extends JavaModuleTests with JacocoTestModule with TestModule.Junit4
+  // but here
+  object customTest extends JavaModuleTests with JacocoTestModule with TestModule.Junit4 {
     override def ivyDeps: T[Agg[Dep]] = super.ivyDeps() ++ Agg(
       ivy"com.novocode:junit-interface:0.11",
       ivy"junit:junit:4.12"
@@ -17,16 +20,16 @@ object main extends JavaModule {
 }
 
 def verify(millVersion: String): Command[Unit] = T.command {
-  val destDir =
-    if (millVersion.startsWith("0.9")) "jacocoReportFull" :: "dest" :: Nil
-    else "jacocoReportFull.dest" :: Nil
-  val jacocoPath = os.pwd / "out" / "de" / "tobiasroeser" / "mill" / "jacoco" / "Jacoco" / destDir
-
+  val jacocoPath = os.pwd / "out" / "de" / "tobiasroeser" / "mill" / "jacoco" / "Jacoco" / "jacocoReportFull.dest"
   val xml = jacocoPath / "jacoco.xml"
   assert(os.exists(jacocoPath))
   assert(os.exists(xml))
   val contents = os.read(xml)
   assert(contents.contains("""<class name="test/Main" sourcefilename="Main.java">"""))
   assert(contents.contains("""<sourcefile name="Main.java">"""))
+  if (millVersion.startsWith("0.11.") && millVersion.drop(5).takeWhile(_.isDigit).toInt >= 7) {
+    // this file should be excluded from report, as it belongs to the test sources
+    assert(!contents.contains("""<class name="test/MainTest" sourcefilename="MainTest.java">"""))
+  }
   ()
 }

--- a/itest/src-0.11+/custom-test/main/customTest/src/test/MainTest.java
+++ b/itest/src-0.11+/custom-test/main/customTest/src/test/MainTest.java
@@ -1,0 +1,10 @@
+package test;
+
+import org.junit.Test;
+
+public class MainTest {
+    @Test
+    public void testMain() {
+        Main.main(new String[]{});
+    }
+}

--- a/itest/src-0.11+/custom-test/main/src/test/Main.java
+++ b/itest/src-0.11+/custom-test/main/src/test/Main.java
@@ -1,0 +1,7 @@
+package test;
+
+class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello Main!");
+    }
+}

--- a/itest/src/simple-java/main/test/src/test/MainTest.java
+++ b/itest/src/simple-java/main/test/src/test/MainTest.java
@@ -1,0 +1,10 @@
+package test;
+
+import org.junit.Test;
+
+public class MainTest {
+    @Test
+    public void testMain() {
+        Main.main(new String[]{});
+    }
+}


### PR DESCRIPTION
This prepared mill-jacoco to better catch exactly the correct module sources. It especially detects any custom test module and excludes it's coverage data from the reports. Perviously, we only detected test modules by naming conventions, which was rather sloppy.

Fix https://github.com/lefou/mill-jacoco/issues/3

This feature only works when used with Mill 0.11.7 or newer. This is a soft requirement and will checked at runtime.